### PR TITLE
Fix references to File class constant which break when used with tty-file

### DIFF
--- a/lib/tty/config.rb
+++ b/lib/tty/config.rb
@@ -600,13 +600,13 @@ module TTY
       when *EXTENSIONS[:yaml]
         load_read_dep('yaml', ext)
         if YAML.respond_to?(:safe_load)
-          YAML.safe_load(File.read(file))
+          YAML.safe_load(::File.read(file))
         else
-          YAML.load(File.read(file))
+          YAML.load(::File.read(file))
         end
       when *EXTENSIONS[:json]
         load_read_dep('json', ext)
-        JSON.parse(File.read(file))
+        JSON.parse(::File.read(file))
       when *EXTENSIONS[:toml]
         load_read_dep('toml', ext)
         TOML.load(::File.read(file))


### PR DESCRIPTION
### Describe the change
Issue in question is #7. Fixes uses of the `File` class constant in `config.rb` which were not explicitly using the root namespace (`::File`). When used in conjunction with `tty-file`, these references caused unavoidable `undefined method` errors because `File` was understood by Ruby to mean `TTY::File`, not `::File`.

### Why are we doing this?
Because when using `tty-file` with this gem at the same time, the
affected section of code is completely broken.

### Benefits
Compatibility with sister gem `tty-file` is improved.

### Drawbacks
None, clearly the original author of the code intended `File` to be the
Ruby core `::File`, and not `TTY::File`.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?