### PR TITLE
[FIXED] self.class returns Class and self returns App.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ class App
   end
 
   def self.config
-    @config ||= self.class.new.config
+    @config ||= self.new.config
   end
 end
 ```


### PR DESCRIPTION
### Describe the change

Fix bug into "1.1 app" example.

Change method:
```ruby
class App
  ..
  def self.config
    @config ||= self.class.new.config
  end
end
```

by this new one:
```ruby
class App
  ..
  def self.config
    @config ||= self.new.config
  end
end
```

### Why?

Because "config" method exists on App class or App instances but no on Class class.
